### PR TITLE
Remove java classes from logic with getting superclass fields.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.iterexoff</groupId>
     <artifactId>soapSteps</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <modules>
         <module>soap-steps-maven-plugin</module>
         <module>soapStepsGenerator</module>

--- a/soap-steps-maven-plugin/pom.xml
+++ b/soap-steps-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>soapSteps</artifactId>
         <groupId>com.iterexoff</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/soapStepsGenerator/pom.xml
+++ b/soapStepsGenerator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>soapSteps</artifactId>
         <groupId>com.iterexoff</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/soapStepsGenerator/src/main/java/com/iterexoff/soapStepsGenerator/utils/ClassUtils.java
+++ b/soapStepsGenerator/src/main/java/com/iterexoff/soapStepsGenerator/utils/ClassUtils.java
@@ -178,7 +178,7 @@ public class ClassUtils extends org.apache.commons.lang3.ClassUtils {
 
     public static List<Field> getDeclaredFieldsWithSuperclasses(Class<?> inputClass) {
         List<Field> fields = new ArrayList<>();
-        for (Class<?> clazz = inputClass; clazz != Object.class; clazz = clazz.getSuperclass()) {
+        for (Class<?> clazz = inputClass; !isJavaBaseClass(clazz); clazz = clazz.getSuperclass()) {
             fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
         }
         return fields;


### PR DESCRIPTION
It tried to generate checks for java core classes when it got fields from all superclasses.
Now getting field from superclasses is stopping if find superclass with java core type.